### PR TITLE
Added options to plot a 'relative_week' and 'relative_day' Dotted Cha…

### DIFF
--- a/R/dotted_chart.R
+++ b/R/dotted_chart.R
@@ -1,19 +1,31 @@
-
 #' @title Dotted chart
 #' @description Create a dotted chart to view all events in a glance
 #' @param eventlog Eventlog object
-#' @param x Value for plot on x-axis: absolute time or relative time (since start)
+#' @param x Value for plot on x-axis: absolute time or relative time (since start, since start of week, since start of day)
 #' @param y Ordering of the cases on y-axis: start, end or duration
 #' @param color Optional, variable to use for coloring dots. Default is the activity identifier. Use NA for no colors.
 #' @param units Time units to use on x-axis in case of relative time.
 #'
 #' @export dotted_chart
 dotted_chart <- function(eventlog,
-						 x = c("absolute","relative"),
+						 x = c("absolute","relative","relative_week","relative_day"),
 						 y = c("start","end","duration"),
 						 color = NULL,
-						 units = c("weeks","days","hours","mins")) {
+						 units = c("weeks","days","hours","mins","secs")) {
 
+
+	#Utility functions for week/day caluclations
+	timeSinceStartOfWeek <- function(time) {
+		midnight <- trunc(time, "days")
+		weekDay <- as.integer(format(time, "%w"))
+		weekDay <- ifelse(weekDay, weekDay-1, 6) # Let week start with Monday
+		msSinceMidnight <- difftime(time, midnight, unit="secs")
+		as.difftime(msSinceMidnight + weekDay*24*60*60, units = "secs")
+	}
+	timeSinceStartOfDay <- function(time) {
+		midnight <- trunc(time, "days")
+		difftime(time, midnight, unit="secs")
+	}
 
 	x <- match.arg(x)
 	y <- match.arg(y)
@@ -46,7 +58,11 @@ dotted_chart <- function(eventlog,
 				   end_case = max(end),
 				   dur = as.double(end_case - start_case, units = units)) %>%
 			mutate(start_relative = as.double(start - start_case, units = units),
-				   end_relative = end - start_case) -> data
+				   end_relative = end - start_case) %>%
+			mutate(start_week = as.double(timeSinceStartOfWeek(start), units = units),
+				   end_week = as.double(timeSinceStartOfWeek(end), units = units)) %>%
+			mutate(start_day = as.double(timeSinceStartOfDay(start), units = units),
+				   end_day = as.double(timeSinceStartOfDay(end), units = units)) -> data
 	} else {
 		eventlog %>%
 			rename_("ts" = timestamp(eventlog),
@@ -60,11 +76,12 @@ dotted_chart <- function(eventlog,
 				   end_case = max(end),
 				   dur = as.double(end_case - start_case, units = units)) %>%
 			mutate(start_relative = as.double(start - start_case, units = units),
-				   end_relative = end - start_case) -> data
+				   end_relative = end - start_case) %>%
+			mutate(start_week = as.double(timeSinceStartOfWeek(start), units = units),
+				   end_week = as.double(timeSinceStartOfWeek(end), units = units)) %>%
+			mutate(start_day = as.double(timeSinceStartOfDay(start), units = units),
+				   end_day = as.double(timeSinceStartOfDay(end), units = units)) -> data
 	}
-
-
-
 
 	if(x == "absolute") {
 		if(y == "start") {
@@ -88,6 +105,28 @@ dotted_chart <- function(eventlog,
 			data %>%
 				ggplot(aes(x = start_relative, y = reorder(case_classifier, desc(dur)))) -> p
 		}
+	} else if (x == "relative_week") {
+		if(y == "start") {
+			data %>%
+				ggplot(aes(x = start_week, y = reorder(case_classifier, desc(start_week)))) -> p
+		} else if (y == "end") {
+			data %>%
+				ggplot(aes(x = start_week, y = reorder(case_classifier, desc(end_week))))  -> p
+		} else if (y == "duration") {
+			data %>%
+				ggplot(aes(x = start_week, y = reorder(case_classifier, desc(dur)))) -> p
+		}
+	} else if (x == "relative_day") {
+		if(y == "start") {
+			data %>%
+				ggplot(aes(x = start_day, y = reorder(case_classifier, desc(start_day)))) -> p
+		} else if (y == "end") {
+			data %>%
+				ggplot(aes(x = start_day, y = reorder(case_classifier, desc(end_day))))  -> p
+		} else if (y == "duration") {
+			data %>%
+				ggplot(aes(x = start_day, y = reorder(case_classifier, desc(dur)))) -> p
+		}
 	}
 
 	p + scale_y_discrete(breaks = NULL) -> p
@@ -99,10 +138,27 @@ dotted_chart <- function(eventlog,
 		p + geom_point(color = "grey") -> p
 	}
 
-
+	# time formatter for the week and day options
+	timeFormat <- function(time){
+		substr(format(as.hms(as.double(time, units = "secs") %% (24 * 60 * 60))),0,5)
+	}
 
 	if(x == "relative") {
 		p + scale_x_continuous() + labs(x = glue::glue("Time since start case (in {units})")) -> p
+	} else if (x == "relative_week") {
+		if (units == "secs") {
+			p + scale_x_time(breaks = as.hms(seq(0, 7 * 86400, by = 8 * 3600)), labels = timeFormat) +
+				geom_vline(xintercept = seq(0, 7 * 86400, by = 86400), colour="black") +
+				labs(x = glue::glue("Time since start of week/monday")) -> p
+		} else {
+			p + scale_x_continuous() + labs(x = glue::glue("Time since start of week/monday (in {units})")) -> p
+		}
+	} else if (x == "relative_day") {
+		if (units == "secs") {
+			p + scale_x_time(breaks = as.hms(seq(0, 86400, by = 2 * 3600))) + labs(x = glue::glue("Time since start of day")) -> p
+		} else {
+			p + scale_x_continuous() + labs(x = glue::glue("Time since start of day (in {units})")) -> p
+		}
 	} else {
 		p + labs(x = "Time") -> p
 	}
@@ -115,6 +171,7 @@ dotted_chart <- function(eventlog,
 		theme_light()
 }
 
+
 #' @rdname dotted_chart
 #' @export idotted_chart
 
@@ -124,9 +181,9 @@ idotted_chart <- function(eventlog) {
 		gadgetTitleBar("Interactive Dotted Chart"),
 		miniContentPanel(
 			column(width = 2,
-				   selectizeInput("x", "x-axis:", choices = c("relative","absolute"), selected = "absolute"),
+				   selectizeInput("x", "x-axis:", choices = c("relative","relative_week","relative_day","absolute"), selected = "absolute"),
 				   selectizeInput("y", "y-axis order:", choices = c("start","end","duration"), selected = "start"),
-				   selectizeInput("units", "Time units:", choices = c("min","hours","days","weeks"), selected = "hours"),
+				   selectizeInput("units", "Time units:", choices = c("secs","min","hours","days","weeks"), selected = "hours"),
 				   selectizeInput("color", "Color:", choices = c(NA,NULL,colnames(eventlog)), selected = "event")
 			),
 			column(width = 10,

--- a/man/dotted_chart.Rd
+++ b/man/dotted_chart.Rd
@@ -5,15 +5,15 @@
 \alias{idotted_chart}
 \title{Dotted chart}
 \usage{
-dotted_chart(eventlog, x = c("absolute", "relative"), y = c("start", "end",
-  "duration"), color = NULL, units = c("weeks", "days", "hours", "mins"))
+dotted_chart(eventlog, x = c("absolute","relative","relative_week","relative_day"), y = c("start", "end",
+  "duration"), color = NULL, units = c("weeks", "days", "hours", "mins", "secs"))
 
 idotted_chart(eventlog)
 }
 \arguments{
 \item{eventlog}{Eventlog object}
 
-\item{x}{Value for plot on x-axis: absolute time or relative time (since start)}
+\item{x}{Value for plot on x-axis:  absolute time or relative time (since start, since start of week, since start of day)}
 
 \item{y}{Ordering of the cases on y-axis: start, end or duration}
 


### PR DESCRIPTION
Added options to plot a 'relative_week' and 'relative_day' Dotted Chart. These charts plot the events using the time since the week started or the time since the day started (midnight). Also, I included the time unit 'secs' that enables a nice formatting of the relative time in terms of the more intuitive hh:mm:ss format. I did not yet manage to get weekday labels for the 'relative_week' option, but added vertical bars to help spotting the weekdays. The week starts on Monday, even though that should be probably configurable.

Thanks for the effort on bringing process mining to R. This is very useful to me 👍  
Hope this addition might be helpful for other people too.

Note, that it should probably refactored since there is now quite a bit of ifthenelse duplication :)