### PR TITLE
Add option to customize the edge color

### DIFF
--- a/R/custom.R
+++ b/R/custom.R
@@ -5,6 +5,7 @@
 #' @param attribute The name of the case attribute to visualize (should be numeric)
 #' @param units Character to be placed after values (e.g. EUR for monitary euro values)
 #' @param color_scale Name of color scale to be used for nodes. Defaults to PuBu. See `Rcolorbrewer::brewer.pal.info()` for all options.
+#' @param color_edges The color used for edges. Defaults to dodgerblue4.
 #' @examples
 #' \dontrun{
 #' library(eventdataR)
@@ -29,10 +30,11 @@
 
 
 
-custom <- function(FUN = mean, attribute, units = "", color_scale = "PuBu") {
+custom <- function(FUN = mean, attribute, units = "", color_scale = "PuBu", color_edges = "dodgerblue4") {
   attr(FUN, "attribute") <- attribute
   attr(FUN, "units") <- units
   attr(FUN, "perspective") <- "custom"
   attr(FUN, "color") <- color_scale
+  attr(FUN, "color_edges") <- color_edges
   return(FUN)
 }

--- a/R/frequency.R
+++ b/R/frequency.R
@@ -3,14 +3,15 @@
 #' @param value The type of frequency value to be used:
 #' absolute, relative (percentage of activity instances) or relative_case (percentage of cases the activity occurs in).
 #' @param color_scale Name of color scale to be used for nodes. Defaults to PuBu. See `Rcolorbrewer::brewer.pal.info()` for all options.
+#' @param color_edges The color used for edges. Defaults to dodgerblue4.
 #' @export frequency
 
 
-frequency <- function(value = c("absolute", "relative", "absolute_case", "relative_case"), color_scale = "PuBu") {
+frequency <- function(value = c("absolute", "relative", "absolute_case", "relative_case"), color_scale = "PuBu", color_edges = "dodgerblue4") {
 	value <- match.arg(value)
 	attr(value, "perspective") <- "frequency"
 	attr(value, "color") <- color_scale
-
+	attr(value, "color_edges") <- color_edges
 	return(value)
 }
 

--- a/R/performance.R
+++ b/R/performance.R
@@ -5,12 +5,13 @@
 #' @param flow_time The time to depict on the flows: the inter start time is the time between the start timestamp of consecutive activity instances,
 #' the idle time is the time between the end and start time of consecutive activity instances.
 #' @param color_scale Name of color scale to be used for nodes. Defaults to Reds. See `Rcolorbrewer::brewer.pal.info()` for all options.
+#' @param color_edges The color used for edges. Defaults to red4.
 #' @export performance
 
 
 
 
-performance <- function(FUN = mean, units = c("mins","hours","days","weeks", "months", "quarters", "semesters","years"), flow_time = c("idle_time","inter_start_time"), color_scale = "Reds") {
+performance <- function(FUN = mean, units = c("mins","hours","days","weeks", "months", "quarters", "semesters","years"), flow_time = c("idle_time","inter_start_time"), color_scale = "Reds", color_edges = "red4") {
 	flow_time <- match.arg(flow_time)
 	units <- match.arg(units)
 	attr(FUN, "flow_time") <- flow_time
@@ -37,6 +38,7 @@ performance <- function(FUN = mean, units = c("mins","hours","days","weeks", "mo
 	}
 
 	attr(FUN, "color") <- color_scale
+	attr(FUN, "color_edges") <- color_edges
 
 
 

--- a/R/process_map.R
+++ b/R/process_map.R
@@ -308,7 +308,7 @@ process_map <- function(eventlog, type = frequency("absolute"),
 				   to = edges$to_id,
 				   label = edges$label,
 				   penwidth = edges$penwidth,
-				   color = ifelse(perspective_edges == "performance", "red4", "dodgerblue4"),
+				   color = attr(type_edges, "color_edges"),
 				   fontname = "Arial") -> edges_df
 
 	create_graph(nodes_df, edges_df) %>%


### PR DESCRIPTION
I simply added a separate parameter color_edges to the profiles that is used for the static edge color. this could be extended to allow for more flexible edge coloring based on values similar to the mechanism used for nodes. Then, it could also work with the single parameter 'color_scale'. The only challenge is to decide whether to use a static color or a scale.